### PR TITLE
chore(deps): update google-fonts-helper / nuxt/kit

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "test": "pnpm lint && vitest run --coverage"
   },
   "dependencies": {
-    "@nuxt/kit": "^3.2.3",
+    "@nuxt/kit": "^3.4.2",
     "google-fonts-helper": "^3.3.0",
     "pathe": "^1.1.0"
   },

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
   },
   "dependencies": {
     "@nuxt/kit": "^3.2.3",
-    "google-fonts-helper": "^3.2.4",
+    "google-fonts-helper": "^3.3.0",
     "pathe": "^1.1.0"
   },
   "devDependencies": {


### PR DESCRIPTION
Hello,

This PR update the google-fonts-helper dependency to v3.3 which enables the use of variable fonts through this syntax in the module config:

```ts
googleFonts: {
  families: {
    Inter: {
      wght: "200..800" // or whatever range from 100-900
    }
  }
}
```

This closes https://github.com/nuxt-modules/google-fonts/issues/133