### PR TITLE
docs: update options content for adding families inside module section

### DIFF
--- a/docs/content/en/options.md
+++ b/docs/content/en/options.md
@@ -31,7 +31,7 @@ It is also possible to add fonts directly in the module declaration:
 ```js{}[nuxt.config.js]
 export default defineNuxtConfig({
   modules: [
-    ['@nuxtjs/google-fonts',{
+    ['@nuxtjs/google-fonts', {
         families: {
           Roboto: true,
           Inter: [400, 700],

--- a/docs/content/en/options.md
+++ b/docs/content/en/options.md
@@ -26,6 +26,27 @@ googleFonts: {
 }
 ```
 
+It is also possible to add fonts directly in the module declaration:
+
+```js{}[nuxt.config.js]
+export default defineNuxtConfig({
+  modules: [
+    ['@nuxtjs/google-fonts',{
+        families: {
+          Roboto: true,
+          Inter: [400, 700],
+           'Josefin+Sans': true,
+          Lato: [100, 300],
+          Raleway: {
+            wght: [100, 400],
+            ital: [100]
+          },
+        }
+    }],
+  ],
+})
+```
+
 ## display
 
 The [font-display property](https://developers.google.com/fonts/docs/css2#use_font-display) lets you control what happens while the font is still loading or otherwise unavailable.


### PR DESCRIPTION
It took me a while to figure out how to add font families inside the `module` section of nuxt.config.js, I'm updating the documentation to make it clearer how to do it