### PR TITLE
feat: Include individual text values for each font

### DIFF
--- a/playground/nuxt.config.ts
+++ b/playground/nuxt.config.ts
@@ -6,8 +6,12 @@ export default defineNuxtConfig({
   ],
   googleFonts: {
     families: {
-      Roboto: true,
+      Roboto: {
+        wght: [100, 400],
+        text: 'Roboto'
+      },
       Mulish: true
-    }
+    },
+    text: 'Hello World'
   }
 })

--- a/src/module.ts
+++ b/src/module.ts
@@ -41,7 +41,7 @@ export default defineNuxtModule<ModuleOptions>({
     fontsDir: 'fonts',
     fontsPath: '../fonts'
   },
-  async setup (options, nuxt) {
+  async setup(options, nuxt) {
     // If user hasn't set the display value manually and isn't using
     // a preload, set the default display value to 'swap'
     if (options.display === undefined && !options.preload) {
@@ -69,7 +69,7 @@ export default defineNuxtModule<ModuleOptions>({
     // construct google fonts url
     const resultArray = Object.entries(merge(options, ...fontsParsed).families!).map(([font, value]) => {
       let currentOptions = options
-      if(value.text) {
+      if (value.text) {
         currentOptions = {
           ...currentOptions,
           text: value.text
@@ -77,16 +77,16 @@ export default defineNuxtModule<ModuleOptions>({
         delete value.text
         delete value.families
       }
-      
+
       return {
-      ...currentOptions,
-      families: { [font]: value },
-    }
-  });
+        ...currentOptions,
+        families: { [font]: value },
+      }
+    });
 
 
     const urls = resultArray.map((result) => constructURL(result)).filter((url) => url !== false) as string[];
-    
+
     if (!urls.length) {
       logger.warn('No provided fonts.')
       return
@@ -101,35 +101,35 @@ export default defineNuxtModule<ModuleOptions>({
       const outputFonts: string[] = []
 
       try {
-      for (const url of urls) {
-        const downloader = download(url, {
-          base64: options.base64,
-          overwriting: options.overwriting,
-          outputDir,
-          stylePath: options.stylePath,
-          fontsDir: options.fontsDir,
-          fontsPath: options.fontsPath
-        })
+        for (const url of urls) {
+          const downloader = download(url, {
+            base64: options.base64,
+            overwriting: options.overwriting,
+            outputDir,
+            stylePath: options.stylePath,
+            fontsDir: options.fontsDir,
+            fontsPath: options.fontsPath
+          })
 
 
-        downloader.hook('download-css:done', (url) => {
-          logger.success(url)
-        })
+          downloader.hook('download-css:done', (url) => {
+            logger.success(url)
+          })
 
-        downloader.hook('download-font:done', (font) => {
-          const fontName = font.outputFont.replace(`-${font.outputFont.replace(/.*-/, '')}`, '')
+          downloader.hook('download-font:done', (font) => {
+            const fontName = font.outputFont.replace(`-${font.outputFont.replace(/.*-/, '')}`, '')
 
-          if (!outputFonts.includes(fontName)) {
-            outputFonts.push(fontName)
-            logger.info(fontName)
-          }
-        })
+            if (!outputFonts.includes(fontName)) {
+              outputFonts.push(fontName)
+              logger.info(fontName)
+            }
+          })
 
-        logger.start('Downloading fonts...')
-        await downloader.execute()
-        logger.success('Download fonts completed.')
-        logger.log('')
-    }
+          logger.start('Downloading fonts...')
+          await downloader.execute()
+          logger.success('Download fonts completed.')
+          logger.log('')
+        }
 
 
         if (options.inject) {
@@ -142,7 +142,7 @@ export default defineNuxtModule<ModuleOptions>({
         nuxt.options.nitro.publicAssets.push({ dir: outputDir })
       } catch (e) {
         logger.error(e)
-      } 
+      }
 
       return
     }
@@ -181,24 +181,24 @@ export default defineNuxtModule<ModuleOptions>({
     if (options.preload) {
       for (const url of urls) {
 
-      head.link.push({
-        key: 'gf-preload',
-        rel: 'preload',
-        as: 'style',
-        href: url
-      })
-    }
+        head.link.push({
+          key: 'gf-preload',
+          rel: 'preload',
+          as: 'style',
+          href: url
+        })
+      }
     }
 
     // append CSS
     if (options.useStylesheet) {
       for (const url of urls) {
-      head.link.push({
-        key: 'gf-style',
-        rel: 'stylesheet',
-        href: url
-      })
-    }
+        head.link.push({
+          key: 'gf-style',
+          rel: 'stylesheet',
+          href: url
+        })
+      }
       return
     }
 
@@ -229,7 +229,7 @@ export default defineNuxtModule<ModuleOptions>({
     }
 
     // JS to inject CSS
-    for(const url of urls) {
+    for (const url of urls) {
       head.script.unshift({
         key: 'gf-script',
         children: `(function(){

--- a/src/module.ts
+++ b/src/module.ts
@@ -67,7 +67,7 @@ export default defineNuxtModule<ModuleOptions>({
 
 
     // construct google fonts url
-    const resultArray = Object.entries(merge(options, ...fontsParsed).families!).map(([font, value]) => {
+    const fontOptionsList = Object.entries(merge(options, ...fontsParsed).families!).map(([font, value]) => {
       let currentOptions = options
       if (value.text) {
         currentOptions = {
@@ -85,7 +85,7 @@ export default defineNuxtModule<ModuleOptions>({
     });
 
 
-    const urls = resultArray.map((result) => constructURL(result)).filter((url) => url !== false) as string[];
+    const urls = fontOptionsList.map((result) => constructURL(result)).filter((url) => url !== false) as string[];
 
     if (!urls.length) {
       logger.warn('No provided fonts.')


### PR DESCRIPTION
**Current Situation**:
Currently, as reported in #106, it is not possible to include only the requested text for each individual font. The current implementation fetches the entire font data in one call, and there is no way to specify separate text values for each font using the Google API.

**Proposed Solution**:
To enable this feature, we need to modify the font fetching process and split it into separate calls. By doing so, we can include only the requested text for each font. This adjustment will ensure that the Google API can handle separate text values for individual fonts.

I would love to someone who is more experienced with Nuxt modules to check if the downloading still works as expected.