### PR TITLE
feat: Add `crossOrigin` option

### DIFF
--- a/src/module.ts
+++ b/src/module.ts
@@ -164,6 +164,7 @@ export default defineNuxtModule<ModuleOptions>({
         key: 'gf-preload',
         rel: 'preload',
         as: 'style',
+        crossOrigin: options.crossOrigin,
         href: url
       })
     }

--- a/src/module.ts
+++ b/src/module.ts
@@ -11,6 +11,7 @@ export interface ModuleOptions extends DownloadOptions, GoogleFonts {
   preconnect?: boolean
   preload?: boolean
   useStylesheet?: boolean
+  crossOrigin?: String | null,
   download?: boolean
   inject?: boolean
 }
@@ -32,6 +33,7 @@ export default defineNuxtModule<ModuleOptions>({
     preconnect: true,
     preload: false,
     useStylesheet: false,
+    crossOrigin: null,
     download: true,
     base64: false,
     inject: true,
@@ -177,11 +179,13 @@ export default defineNuxtModule<ModuleOptions>({
       return
     }
 
+    const crossOriginAttribute = options.crossOrigin !== null ? `l.crossOrigin=${options.crossOrigin};` : ''
+
     if (isNuxt2()) {
       // JS to inject CSS
       head.script.push({
         key: 'gf-script',
-        innerHTML: `(function(){var l=document.createElement('link');l.rel="stylesheet";l.href="${url}";document.querySelector("head").appendChild(l);})();`
+        innerHTML: `(function(){var l=document.createElement('link');l.rel="stylesheet";l.href="${url}";${crossOriginAttribute}document.querySelector("head").appendChild(l);})();`
       })
 
       // no-JS fallback
@@ -210,7 +214,7 @@ export default defineNuxtModule<ModuleOptions>({
         var m=h.querySelector('meta[name="head:count"]');
         if(m){m.setAttribute('content',Number(m.getAttribute('content'))+1);}
         else{m=document.createElement('meta');m.setAttribute('name','head:count');m.setAttribute('content','1');h.append(m);}
-        var l=document.createElement('link');l.rel='stylesheet';l.href='${url}';h.appendChild(l);
+        var l=document.createElement('link');l.rel='stylesheet';l.href='${url}';${crossOriginAttribute}h.appendChild(l);
       })();`
     })
 

--- a/test/crossorigin.test.ts
+++ b/test/crossorigin.test.ts
@@ -1,0 +1,28 @@
+import { describe, test, expect } from 'vitest'
+import { setup, $fetch } from '@nuxt/test-utils'
+
+describe('crossOrigin', async () => {
+  await setup({
+    nuxtConfig: {
+      app: {
+        head: {
+          link: [
+            { rel: 'stylesheet', href: 'https://fonts.googleapis.com/css?family=Lato' }
+          ]
+        }
+      },
+      googleFonts: {
+        families: {
+          Roboto: true
+        },
+        download: false,
+        crossOrigin: 'anonymous'
+      }
+    }
+  })
+
+  test('has crossorigin="anonymous" attribute', async () => {
+    const body = await $fetch('/')
+    expect(body).toContain('crossorigin="anonymous"')
+  })
+})


### PR DESCRIPTION
Adds `crossOrigin` option.

> The crossorigin attribute indicates whether the resource should be fetched with a CORS request as the font may come from a different domain. Without this attribute, the preloaded font is ignored by the browser.

https://web.dev/articles/codelab-preload-web-fonts#preloading_web_fonts

And without `crossorigin=anonymous` libraries like [html-to-image](https://github.com/bubkoo/html-to-image) are unable to use the correct font.