### PR TITLE
fix: update ModuleOptions interface in module.ts

### DIFF
--- a/src/module.ts
+++ b/src/module.ts
@@ -6,7 +6,7 @@ import { name, version } from '../package.json'
 
 type NuxtAppHead = Required<MetaObject>
 
-export interface ModuleOptions extends DownloadOptions, GoogleFonts {
+export interface ModuleOptions extends Partial<DownloadOptions>, GoogleFonts {
   prefetch?: boolean
   preconnect?: boolean
   preload?: boolean


### PR DESCRIPTION
![CleanShot 2024-01-22 at 18 34 16](https://github.com/nuxt-modules/google-fonts/assets/38668796/c5389275-65be-460a-8a24-45eda2b49d47)

gives an error for these, but they are not required fields.


https://github.com/nuxt-modules/google-fonts/blob/dbd45b4713335840d4ad9ab66b3cfa352ec8e7f1/src/module.ts#L39-L43
