### PR TITLE
docs: use new `nuxi module add` command in installation

### DIFF
--- a/docs/content/0.index.md
+++ b/docs/content/0.index.md
@@ -12,7 +12,7 @@ cta:
 secondary:
   - Star on GitHub →
   - https://github.com/nuxt-modules/google-fonts
-snippet: npm i -D @nuxtjs/google-fonts
+snippet: npx nuxi@latest module add google-fonts
 ---
 
 #title

--- a/docs/content/1.getting-started/1.setup.md
+++ b/docs/content/1.getting-started/1.setup.md
@@ -5,22 +5,9 @@ Using Google Fonts in your Nuxt project
 ## Installation
 
 1. Install `@nuxtjs/google-fonts` dependency to your project:
-
-::code-group
-
-```bash [yarn]
-yarn add -D @nuxtjs/google-fonts
+```bash
+npx nuxi@latest module add google-fonts
 ```
-
-```bash [npm]
-npm install -D @nuxtjs/google-fonts
-```
-
-```sh [pnpm]
-pnpm i -D @nuxtjs/google-fonts
-```
-
-::
 
 2. Add it to your `modules` section in your `nuxt.config`:
 


### PR DESCRIPTION

This updates the documentation to use the [`nuxi module add` command](https://github.com/nuxt/cli/pull/197) which should simplify docs a bit and also improve user experience as there's no need to add to `nuxt.config` manually.

It's documented [here](https://nuxt.com/docs/api/commands/module#nuxi-module-add).

I may have missed a few spots in the documentation as I'm doing this across the modules ecosystem assisted by the power of regular expressions ✨, so I'd appreciate a review 🙏
