### PR TITLE
fix: Change duplicate Inter font declare on setup

### DIFF
--- a/docs/content/1.getting-started/1.setup.md
+++ b/docs/content/1.getting-started/1.setup.md
@@ -45,7 +45,7 @@ export default defineNuxtConfig({
     ['@nuxtjs/google-fonts', {
         families: {
           Roboto: true,
-          Inter: [400, 700],
+          Lato: [400, 700],
           'Josefin+Sans': true,
           Lato: [100, 300],
           Raleway: {


### PR DESCRIPTION
Change font Inter to other font for fix: An object literal cannot have multiple properties with the same name.

![image](https://github.com/user-attachments/assets/e4086b28-3ea2-4431-b1a8-662f09f377f4)
